### PR TITLE
Fixed empty names during account creation

### DIFF
--- a/client/components/CreateUser.js
+++ b/client/components/CreateUser.js
@@ -16,12 +16,17 @@ function CreateUser() {
 
     function submitForm(e) {
         e.preventDefault();
-        if (!firstName || !lastName || !username || !password || !color) {
+
+        const trimmedFirstName = firstName.trim();
+        const trimmedLastName = lastName.trim();
+        const trimmedUsername = username.trim();
+        
+        if (!trimmedFirstName || !trimmedLastName || !trimmedUsername || !password || !color) {
             setErrorMessage("All fields must be filled");
             return;
         }
 
-        if (firstName.length > 50 || lastName.length > 50 || username.length > 50 || password.length > 50) {
+        if (trimmedFirstName.length > 50 || trimmedLastName.length > 50 || trimmedUsername.length > 50 || password.length > 50) {
             setErrorMessage("Input exceeds maximum length of 50 characters");
             return;
         }
@@ -42,9 +47,9 @@ function CreateUser() {
                 'Content-Type': 'application/json',
             },
             body: JSON.stringify({
-                firstName,
-                lastName,
-                username,
+                firstName: trimmedFirstName,
+                lastName: trimmedLastName,
+                username: trimmedUsername,
                 password,
                 color
             }),

--- a/controllers/createUser.js
+++ b/controllers/createUser.js
@@ -5,6 +5,10 @@ const createUser = async (req, res, models) => {
 
     let { firstName, lastName, username, password, color } = req.body;
 
+    firstName = firstName.trim();
+    lastName = lastName.trim();
+    username = username.trim();
+
     if (!firstName || !lastName || !username || !password) {
         res.status(400).json({ success: false, message: 'All fields are required' });
         return;


### PR DESCRIPTION
Fixes #7 

The first name, last name and username inputs are stripped of all whitespace characters using `trim()`, so now accounts with empty usernames can no longer be made.